### PR TITLE
make max nodes great again

### DIFF
--- a/lib/k8s_node_descale/command.rb
+++ b/lib/k8s_node_descale/command.rb
@@ -47,6 +47,7 @@ module K8sNodeDescale
         signal_usage_error 'failed to connect to Kubernetes API, see --help for connection options (%s)' % ex.message
       end
 
+      terminated_count = 0
       scheduler.run do
         Log.debug { "Requesting node information .." }
 
@@ -73,6 +74,12 @@ module K8sNodeDescale
             end
             drain_node(name)
             Log.debug { "Done draining node %s" % name }
+
+            terminated_count += 1
+            if terminated_count >= max_nodes
+              Log.info "Reached termination --max-nodes count, breaking cycle."
+              break
+            end
           else
             Log.debug { "Node %s has not reached best-before" % name }
           end


### PR DESCRIPTION
max nodes termination is removed first in
https://github.com/kontena/k8s-node-descale/commit/02027637d3b383d34305e5b220b1121db91e3a7a#diff-3cded7fae6034842994f72c9da80d8fbL151

and then finally the last "terminated_count = 0" gets removed in
https://github.com/kontena/k8s-node-descale/commit/f8bb5bf502005531ef54aa5b335943ddb55f7da6#diff-3cded7fae6034842994f72c9da80d8fbL71

0 specs, 0 failures!